### PR TITLE
suggestions

### DIFF
--- a/pkg/consolegraphql/resolvers/resolver_address.go
+++ b/pkg/consolegraphql/resolvers/resolver_address.go
@@ -7,14 +7,12 @@ package resolvers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"github.com/enmasseproject/enmasse/pkg/apis/admin/v1beta2"
 	"github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1beta1"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/cache"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/server"
-	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"strings"
@@ -197,23 +195,8 @@ func (r *queryResolver) AddressCommand(ctx context.Context, input v1beta1.Addres
 		input.TypeMeta.Kind = "Address"
 	}
 
-	bytes, err := json.Marshal(input)
-	if err != nil {
-		return "", err
-	}
+	namespace := input.Namespace
+	input.Namespace = ""
 
-	jsonMap := make(map[string]interface{})
-	err = json.Unmarshal(bytes, &jsonMap)
-
-	if err != nil {
-		return "", err
-	}
-
-	bytes, err = yaml.Marshal(jsonMap)
-
-	if err == nil {
-		return  "oc apply -f - << EOF \n" +string(bytes)+ "\nEOF", nil
-	} else {
-		return "", err
-	}
+	return generateApplyCommand(input, namespace)
 }

--- a/pkg/consolegraphql/resolvers/resolver_address_test.go
+++ b/pkg/consolegraphql/resolvers/resolver_address_test.go
@@ -340,17 +340,13 @@ func TestAddressCommand(t *testing.T) {
 	r,ctx := newTestAddressResolver(t)
 	namespace := "mynamespace"
 	addr := createAddress(namespace, "myaddrspace.myaddr")
-	err := r.Cache.Add(addr)
-	assert.NoError(t, err)
 
 	cmd, err := r.Query().AddressCommand(ctx, addr.Address)
 
 	assert.NoError(t, err)
 	expected := `kind: Address
 metadata:
-  creationTimestamp: null
-  name: myaddrspace.myaddr
-  namespace: mynamespace`
+  name: myaddrspace.myaddr`
 	assert.Contains(t, cmd, expected, "Expect name and namespace to be set")
 }
 

--- a/pkg/consolegraphql/resolvers/resolver_addressspace.go
+++ b/pkg/consolegraphql/resolvers/resolver_addressspace.go
@@ -7,14 +7,12 @@ package resolvers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"github.com/enmasseproject/enmasse/pkg/apis/admin/v1beta2"
 	"github.com/enmasseproject/enmasse/pkg/apis/enmasse/v1beta1"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/cache"
 	"github.com/enmasseproject/enmasse/pkg/consolegraphql/server"
-	yaml "gopkg.in/yaml.v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -250,23 +248,8 @@ func (r *queryResolver) AddressSpaceCommand(ctx context.Context, input v1beta1.A
 		input.TypeMeta.Kind = "AddressSpace"
 	}
 
-	bytes, err := json.Marshal(input)
-	if err != nil {
-		return "", err
-	}
+	namespace := input.Namespace
+	input.Namespace = ""
 
-	jsonMap := make(map[string]interface{})
-	err = json.Unmarshal(bytes, &jsonMap)
-
-	if err != nil {
-		return "", err
-	}
-
-	bytes, err = yaml.Marshal(jsonMap)
-
-	if err == nil {
-		return  "oc apply -f - << EOF \n" +string(bytes)+ "\nEOF", nil
-	} else {
-		return "", err
-	}
+	return generateApplyCommand(input, namespace)
 }

--- a/pkg/consolegraphql/resolvers/resolver_addressspace_test.go
+++ b/pkg/consolegraphql/resolvers/resolver_addressspace_test.go
@@ -247,17 +247,13 @@ func TestQueryAddressSpaceCommand(t *testing.T) {
 		Plan: "standard-small-queue",
 		Type: "queue",
 	}
-	err := r.Cache.Add(as)
-	assert.NoError(t, err)
 	obj, err := r.Query().AddressSpaceCommand(ctx, as.AddressSpace)
 	assert.NoError(t, err)
 
 	assert.NoError(t, err)
 	expectedMetaData := `kind: AddressSpace
 metadata:
-  creationTimestamp: null
-  name: mynamespace
-  namespace: myaddressspace`
+  name: mynamespace`
 	expectedSpec := `
 spec:
   authenticationService:

--- a/pkg/consolegraphql/resolvers/utils.go
+++ b/pkg/consolegraphql/resolvers/utils.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020, EnMasse authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ *
+ */
+
+package resolvers
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/enmasseproject/enmasse/pkg/util"
+	"gopkg.in/yaml.v2"
+)
+
+func generateApplyCommand(object interface{}, namespace string) (string, error) {
+	var namespaceArgument string
+	if namespace != "" {
+		namespaceArgument = fmt.Sprintf("--namespace=%s ", namespace)
+	}
+
+	bytes, err := json.Marshal(object)
+	if err != nil {
+		return "", err
+	}
+
+	jsonMap := make(map[string]interface{})
+	err = json.Unmarshal(bytes, &jsonMap)
+	if err != nil {
+		return "", err
+	}
+
+	delete(jsonMap, "status")
+	delete(jsonMap["metadata"].(map[string]interface{}), "creationTimestamp")
+	delete(jsonMap["metadata"].(map[string]interface{}), "uid")
+
+	bytes, err = yaml.Marshal(jsonMap)
+
+	kubectl := "kubectl"
+	if util.IsOpenshift() {
+		kubectl = "oc"
+	}
+
+	if err == nil {
+		shell := fmt.Sprintf("%s apply %s-f - << EOF \n%s\nEOF", kubectl, namespaceArgument, string(bytes))
+		return shell, nil
+	} else {
+		return "", err
+	}
+}


### PR DESCRIPTION
The `creationTimestamp: null` bothered me, so I have filtered it out, along with the UID.  With the namespace, I think the command is most useful when the namespace is parameterised as a command line argument.  That way the user can apply the same resource to different namespaces unchanged.

I also added support for kubectl for kubernetes.
